### PR TITLE
Added ENV to prevent error for running as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster-slim
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV QTWEBENGINE_DISABLE_SANDBOX=1
 
 RUN apt-get update && \
     apt-get install -y jackd1 jack-tools icecast2 darkice supercollider xvfb && \


### PR DESCRIPTION
Wasnt able to run it out of the box. Was getting thiis error:

```
[52:52:0707/091738.662614:ERROR:zygote_host_impl_linux.cc(90)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
terminate called without an active exception
```
Based on this: https://github.com/supercollider/supercollider/issues/4301

Also, using `docker run --privileged=true` suppresses a few other errors. This isn't required for it to work though.